### PR TITLE
Fix time synchronization API method syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1024,7 +1024,7 @@ If the device is online, the device using the system time synchronization SNTP, 
 
 If the device is online, you can use to adjust the system time:
 
-http://$ReceiverIpAddress/httpapi.asp?command= Timesync: YYYYMMDDHHMMSS
+http://$ReceiverIpAddress/httpapi.asp?command=timeSync:YYYYMMDDHHMMSS
 
 ## Set the timer
 the URinterface:


### PR DESCRIPTION
The Time synchronization section had series of typos. 
Corrected and tested syntax proposed.
E.g. call: `http://10.10.10.254/httpapi.asp?command=timeSync:20181220144405`