### PR TITLE
Add Audio Pro to device list

### DIFF
--- a/devices.md
+++ b/devices.md
@@ -8,3 +8,4 @@
 | Muzo | Cobblestone | -|
 |Venz |A501| - |
 | SACKit | MOVEit | Sells other models, probably with the same protocol |
+| Audio Pro | A10, A23, A36, A40, Addon C3/C5/C5A/C10/C-SUB, D-1, Drumfire, Link 1| - |

--- a/devices.md
+++ b/devices.md
@@ -1,11 +1,10 @@
 |Brand | model | comment |
 |------|------|--------|
-| Sonoé | iEast | -
-| Roxcore | Roxcore | Sold by kjell & company |
-| Stereoboommm  | MR200 | - |
-| Stereoboommm  | MR300 | - |
+| Audio Pro | A10, A23, A36, A40, Addon C3/C5/C5A/C10/C-SUB, D-1, Drumfire, Link 1| - |
 | August  | media players | Specific models unknown |
 | Muzo | Cobblestone | -|
-|Venz |A501| - |
+| Roxcore | Roxcore | Sold by kjell & company |
 | SACKit | MOVEit | Sells other models, probably with the same protocol |
-| Audio Pro | A10, A23, A36, A40, Addon C3/C5/C5A/C10/C-SUB, D-1, Drumfire, Link 1| - |
+| Sonoé | iEast | -
+| Stereoboommm  | MR200, MR300 | - |
+| Venz |A501| - |


### PR DESCRIPTION
I added the Audio Pro family of multiroom devices (http://audiopro.com/en) to devices.md. I also sorted the list alphabetically to make it easier to read.